### PR TITLE
Add data preprocessing CLI scripts

### DIFF
--- a/data_preprocessing/create_fusion_csv.py
+++ b/data_preprocessing/create_fusion_csv.py
@@ -1,0 +1,74 @@
+import argparse
+import os
+import pandas as pd
+
+from src.data import load_weights, apply_weights_to_directory
+
+
+def build_csv(cwt_dir: str, ssi_dir: str) -> pd.DataFrame:
+    rows = []
+    for split in ["train", "val", "test"]:
+        img_split_dir = os.path.join(cwt_dir, split)
+        if not os.path.isdir(img_split_dir):
+            continue
+        for root, _, files in os.walk(img_split_dir):
+            for file in files:
+                if file.endswith(".png"):
+                    image_path = os.path.join(root, file)
+                    rel = os.path.relpath(image_path, cwt_dir)
+                    parts = rel.split(os.sep)
+                    if len(parts) < 5:
+                        continue
+                    _, classe, test_id, capteur, name = parts
+                    ssi_name = name.replace(".png", "_weighted.npy")
+                    ssi_path = os.path.join(ssi_dir, split, classe, test_id, capteur, ssi_name)
+                    rows.append({
+                        "image_path": image_path,
+                        "ssi_path": ssi_path,
+                        "label": classe,
+                        "split": split,
+                    })
+    return pd.DataFrame(rows)
+
+
+def main(cwt_dir: str, ssi_dir: str, weights_csv: str, output_csv: str) -> None:
+    if weights_csv:
+        weights = load_weights(weights_csv)
+        apply_weights_to_directory(ssi_dir, weights)
+    df = build_csv(cwt_dir, ssi_dir)
+    df.to_csv(output_csv, index=False)
+    print(f"Saved fusion CSV to {output_csv}")
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(description="Create fusion dataset CSV")
+    parser.add_argument(
+        "--cwt-dir",
+        type=str,
+        default="/content/drive/MyDrive/CWT_images",
+        help="Directory containing CWT images",
+    )
+    parser.add_argument(
+        "--ssi-dir",
+        type=str,
+        default="/content/drive/MyDrive/SSI_vectors",
+        help="Directory containing SSI vectors",
+    )
+    parser.add_argument(
+        "--weights-csv",
+        type=str,
+        default="",
+        help="Optional weighting table to apply",
+    )
+    parser.add_argument(
+        "--output-csv",
+        type=str,
+        default="/content/drive/MyDrive/dataset_fusion_weighted.csv",
+        help="Path to output CSV",
+    )
+    args = parser.parse_args()
+    main(args.cwt_dir, args.ssi_dir, args.weights_csv, args.output_csv)
+
+
+if __name__ == "__main__":
+    cli()

--- a/data_preprocessing/generate_cwt_images.py
+++ b/data_preprocessing/generate_cwt_images.py
@@ -1,0 +1,88 @@
+import argparse
+import os
+import pickle
+from typing import Optional
+
+import torch
+
+from src.data import generate_cwt_images
+
+
+def load_ffdnet(model_path: Optional[str], device: torch.device) -> torch.nn.Module:
+    """Load FFDNet from timm or local weights."""
+    try:
+        import timm
+    except Exception:
+        timm = None
+
+    if model_path and os.path.isfile(model_path):
+        if timm is None:
+            raise RuntimeError("timm is required to instantiate FFDNet")
+        model = timm.create_model("ffdnet", pretrained=False)
+        state = torch.load(model_path, map_location=device)
+        model.load_state_dict(state)
+    else:
+        if timm is None:
+            raise RuntimeError("timm is required to load pretrained FFDNet")
+        model = timm.create_model("ffdnet", pretrained=True)
+
+    model.to(device)
+    model.eval()
+    return model
+
+
+def main(
+    segments_path: str,
+    split_path: str,
+    output_dir: str,
+    model_path: Optional[str],
+    device_str: str,
+) -> None:
+    device = torch.device(device_str)
+    with open(segments_path, "rb") as f:
+        segments_fbg = pickle.load(f)
+    with open(split_path, "rb") as f:
+        split_tags = pickle.load(f)
+
+    model = load_ffdnet(model_path, device)
+    generate_cwt_images(segments_fbg, split_tags, output_dir, model, device)
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(description="Generate CWT images")
+    parser.add_argument(
+        "--segments-path",
+        type=str,
+        default="/content/drive/MyDrive/segments_fbg.pkl",
+        help="Path to segments_fbg.pkl",
+    )
+    parser.add_argument(
+        "--split-path",
+        type=str,
+        default="/content/drive/MyDrive/split_segments.pkl",
+        help="Path to split_segments.pkl",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="/content/drive/MyDrive/CWT_images",
+        help="Directory to store generated images",
+    )
+    parser.add_argument(
+        "--model-path",
+        type=str,
+        default="",
+        help="Optional path to FFDNet weights",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Computation device",
+    )
+    args = parser.parse_args()
+    main(args.segments_path, args.split_path, args.output_dir, args.model_path, args.device)
+
+
+if __name__ == "__main__":
+    cli()

--- a/data_preprocessing/generate_ssi_vectors.py
+++ b/data_preprocessing/generate_ssi_vectors.py
@@ -1,0 +1,82 @@
+import argparse
+import pickle
+
+from src.data import generate_ssi_vector
+
+
+def main(
+    segments_path: str,
+    split_path: str,
+    output_dir: str,
+    decim: int,
+    lags: int,
+    order: int,
+    top_k: int,
+) -> None:
+    with open(segments_path, "rb") as f:
+        segments_fbg = pickle.load(f)
+    with open(split_path, "rb") as f:
+        split_tags = pickle.load(f)
+
+    for classe, tests in segments_fbg.items():
+        for test_path, capteurs in tests.items():
+            for capteur, segments in capteurs.items():
+                tags = split_tags[classe][test_path][capteur]
+                for idx, segment in enumerate(segments):
+                    tag = tags[idx]
+                    if tag not in {"train", "val", "test"}:
+                        continue
+                    generate_ssi_vector(
+                        segment=segment,
+                        split=tag,
+                        classe=classe,
+                        test_path=test_path,
+                        capteur=capteur,
+                        index=idx,
+                        output_base=output_dir,
+                        decim=decim,
+                        lags=lags,
+                        ordre=order,
+                        top_k=top_k,
+                    )
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(description="Generate SSI vectors")
+    parser.add_argument(
+        "--segments-path",
+        type=str,
+        default="/content/drive/MyDrive/segments_fbg.pkl",
+        help="Path to segments_fbg.pkl",
+    )
+    parser.add_argument(
+        "--split-path",
+        type=str,
+        default="/content/drive/MyDrive/split_segments.pkl",
+        help="Path to split_segments.pkl",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="/content/drive/MyDrive/SSI_vectors",
+        help="Directory to store SSI vectors",
+    )
+    parser.add_argument("--decim", type=int, default=4, help="Decimation factor")
+    parser.add_argument("--lags", type=int, default=40, help="Number of lags")
+    parser.add_argument("--order", type=int, default=20, help="SSI order")
+    parser.add_argument("--top-k", type=int, default=10, help="Top frequencies")
+    args = parser.parse_args()
+
+    main(
+        args.segments_path,
+        args.split_path,
+        args.output_dir,
+        args.decim,
+        args.lags,
+        args.order,
+        args.top_k,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/data_preprocessing/segments_generation.py
+++ b/data_preprocessing/segments_generation.py
@@ -1,0 +1,54 @@
+import argparse
+import os
+import pickle
+
+from hawk_data import FST
+from src.data import segment_fbg, split_segments
+
+
+def main(data_dir: str, output_dir: str) -> None:
+    fst = FST(data_dir)
+    data = getattr(fst, "data", None)
+    if data is None and hasattr(fst, "load"):
+        data = fst.load()
+
+    tests_per_class = getattr(fst, "tests_per_class", None)
+    if tests_per_class is None and hasattr(fst, "get_tests_per_class"):
+        tests_per_class = fst.get_tests_per_class()
+    if tests_per_class is None:
+        raise RuntimeError("Could not obtain test/class mapping from FST")
+
+    segments_fbg = segment_fbg(data, tests_per_class)
+    split_tags = split_segments(segments_fbg)
+
+    os.makedirs(output_dir, exist_ok=True)
+    seg_path = os.path.join(output_dir, "segments_fbg.pkl")
+    split_path = os.path.join(output_dir, "split_segments.pkl")
+    with open(seg_path, "wb") as f:
+        pickle.dump(segments_fbg, f)
+    with open(split_path, "wb") as f:
+        pickle.dump(split_tags, f)
+    print(f"Saved segments to {seg_path}")
+    print(f"Saved split tags to {split_path}")
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(description="Generate FBG segments and split")
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        default="/content/drive/MyDrive/FST",
+        help="Directory containing the raw FBG dataset",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="/content/drive/MyDrive",
+        help="Directory where the pickle files will be stored",
+    )
+    args = parser.parse_args()
+    main(args.data_dir, args.output_dir)
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- add `segments_generation.py` to create pickles for FBG segments and splits
- add `generate_cwt_images.py` to create denoised CWT images
- add `generate_ssi_vectors.py` to compute SSI vectors
- add `create_fusion_csv.py` to build a CSV mapping images and weighted vectors

## Testing
- `python -m py_compile data_preprocessing/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688c272bffdc832f8e983f5eefe102c9