### PR TITLE
Improve FusionDataset docs

### DIFF
--- a/src/data/fusion_dataset.py
+++ b/src/data/fusion_dataset.py
@@ -10,9 +10,26 @@ import torchvision.transforms as T
 
 
 class FusionDataset(Dataset):
-    """Dataset loading pairs of CWT images and weighted SSI vectors."""
+    """Dataset loading pairs of CWT images and weighted SSI vectors.
+
+    The ``csv_path`` file must contain the following columns:
+
+    - ``image_path``: path to the CWT image file
+    - ``ssi_path``: path to the weighted SSI vector (``.npy``)
+    - ``label``: class label as a string
+    - ``split``: data split tag (``"train"``, ``"val"`` or ``"test"``)
+
+    Example
+    -------
+    >>> from torchvision import transforms
+    >>> ds = FusionDataset("metadata.csv", split="train",
+    ...                    transform=transforms.ToTensor())
+    >>> img, vec, label = ds[0]
+    """
 
     def __init__(self, csv_path: str, split: str = "train", transform=None, label_map=None):
+        self.csv_path = csv_path
+        self.split = split
         self.data = pd.read_csv(csv_path)
         self.data = self.data[self.data["split"] == split].reset_index(drop=True)
         self.transform = transform
@@ -33,3 +50,9 @@ class FusionDataset(Dataset):
         ssi_vector = torch.tensor(np.load(row["ssi_path"]), dtype=torch.float32)
         label = torch.tensor(self.label_map[row["label"]], dtype=torch.long)
         return image, ssi_vector, label
+
+    def __repr__(self) -> str:  # type: ignore[override]
+        return (
+            f"{self.__class__.__name__}(split='{self.split}', "
+            f"num_samples={len(self)})"
+        )


### PR DESCRIPTION
## Summary
- expand the `FusionDataset` documentation with expected CSV format and usage example
- store CSV path and split for debugging
- add a `__repr__` implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c27315060832fbabb914014e80c75