### PR TITLE
Add Swin fusion model and training scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # SSI_Swin_Fusion
 Projet de classification FBG avec SSI + Swin Transformer + CBAM
+
+## Usage example
+
+```python
+from src.models import SSI_SwinFusionNet
+import torch
+
+model = SSI_SwinFusionNet(num_classes=4, ssi_input_dim=64, pretrained=False)
+img = torch.randn(2, 3, 224, 224)
+ssi = torch.randn(2, 64)
+print(model(img, ssi).shape)  # torch.Size([2, 4])
+```

--- a/eval.py
+++ b/eval.py
@@ -1,0 +1,63 @@
+import argparse
+
+import torch
+from torch.utils.data import DataLoader
+from torchvision import transforms
+
+from src.data import FusionDataset
+from src.models import SSI_SwinFusionNet
+
+
+def evaluate(
+    csv_path: str,
+    checkpoint: str,
+    batch_size: int = 8,
+    device: str = "cpu",
+) -> float:
+    """Evaluate a trained :class:`SSI_SwinFusionNet` on the test split."""
+
+    transform = transforms.ToTensor()
+    dataset = FusionDataset(csv_path, split="test", transform=transform)
+    loader = DataLoader(dataset, batch_size=batch_size)
+
+    model = SSI_SwinFusionNet(num_classes=len(dataset.label_map), ssi_input_dim=dataset[0][1].shape[0])
+    state = torch.load(checkpoint, map_location=device)
+    model.load_state_dict(state)
+    model.to(device)
+    model.eval()
+
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for imgs, ssis, labels in loader:
+            imgs = imgs.to(device)
+            ssis = ssis.to(device)
+            labels = labels.to(device)
+            outputs = model(imgs, ssis)
+            preds = outputs.argmax(1)
+            correct += (preds == labels).sum().item()
+            total += labels.size(0)
+
+    acc = correct / total if total else 0.0
+    print(f"Test accuracy: {acc:.4f}")
+    return acc
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate SSI Swin fusion model")
+    parser.add_argument("--csv-path", type=str, required=True, help="Fusion CSV file")
+    parser.add_argument("--checkpoint", type=str, required=True, help="Path to model weights")
+    parser.add_argument("--batch-size", type=int, default=8, help="Batch size")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Computation device",
+    )
+    args = parser.parse_args()
+    evaluate(args.csv_path, args.checkpoint, args.batch_size, args.device)
+
+
+if __name__ == "__main__":
+    cli()
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,34 @@
+import argparse
+
+from train import train
+from eval import evaluate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train or evaluate the model")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    train_p = sub.add_parser("train", help="Train the model")
+    train_p.add_argument("csv_path", type=str, help="Fusion CSV file")
+    train_p.add_argument("--output-dir", type=str, default="checkpoints", help="Output directory")
+    train_p.add_argument("--epochs", type=int, default=5)
+    train_p.add_argument("--batch-size", type=int, default=8)
+    train_p.add_argument("--lr", type=float, default=1e-4)
+    train_p.add_argument("--device", type=str, default="cuda" if __import__("torch").cuda.is_available() else "cpu")
+
+    eval_p = sub.add_parser("eval", help="Evaluate the model")
+    eval_p.add_argument("csv_path", type=str, help="Fusion CSV file")
+    eval_p.add_argument("checkpoint", type=str, help="Model weights")
+    eval_p.add_argument("--batch-size", type=int, default=8)
+    eval_p.add_argument("--device", type=str, default="cuda" if __import__("torch").cuda.is_available() else "cpu")
+
+    args = parser.parse_args()
+    if args.command == "train":
+        train(args.csv_path, args.output_dir, args.epochs, args.batch_size, args.lr, args.device)
+    else:
+        evaluate(args.csv_path, args.checkpoint, args.batch_size, args.device)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,6 @@
+"""Model architectures."""
+from .swin import SSI_SwinFusionNet
+from .cbam import CBAM
+
+__all__ = ["SSI_SwinFusionNet", "CBAM"]
+

--- a/src/models/cbam.py
+++ b/src/models/cbam.py
@@ -1,0 +1,55 @@
+import torch
+from torch import nn
+
+
+class ChannelAttention(nn.Module):
+    """Channel attention module used in CBAM."""
+
+    def __init__(self, channels: int, reduction: int = 16) -> None:
+        super().__init__()
+        mid_channels = max(1, channels // reduction)
+        self.avg_pool = nn.AdaptiveAvgPool2d(1)
+        self.max_pool = nn.AdaptiveMaxPool2d(1)
+        self.mlp = nn.Sequential(
+            nn.Conv2d(channels, mid_channels, kernel_size=1, bias=False),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(mid_channels, channels, kernel_size=1, bias=False),
+        )
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        avg_out = self.mlp(self.avg_pool(x))
+        max_out = self.mlp(self.max_pool(x))
+        attn = self.sigmoid(avg_out + max_out)
+        return x * attn
+
+
+class SpatialAttention(nn.Module):
+    """Spatial attention module used in CBAM."""
+
+    def __init__(self, kernel_size: int = 7) -> None:
+        super().__init__()
+        padding = kernel_size // 2
+        self.conv = nn.Conv2d(2, 1, kernel_size=kernel_size, padding=padding, bias=False)
+        self.sigmoid = nn.Sigmoid()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        avg_out = torch.mean(x, dim=1, keepdim=True)
+        max_out, _ = torch.max(x, dim=1, keepdim=True)
+        concat = torch.cat([avg_out, max_out], dim=1)
+        attn = self.sigmoid(self.conv(concat))
+        return x * attn
+
+
+class CBAM(nn.Module):
+    """Convolutional Block Attention Module."""
+
+    def __init__(self, channels: int, reduction: int = 16, kernel_size: int = 7) -> None:
+        super().__init__()
+        self.channel_att = ChannelAttention(channels, reduction)
+        self.spatial_att = SpatialAttention(kernel_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.channel_att(x)
+        x = self.spatial_att(x)
+        return x

--- a/src/models/swin.py
+++ b/src/models/swin.py
@@ -1,0 +1,62 @@
+"""Swin Transformer based fusion model."""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+try:
+    import timm
+except Exception:  # pragma: no cover - optional dependency
+    timm = None
+
+from .cbam import CBAM
+
+
+class SSI_SwinFusionNet(nn.Module):
+    """Late-fusion network combining Swin Transformer features and SSI vectors."""
+
+    def __init__(self, num_classes: int = 4, ssi_input_dim: int = 64, pretrained: bool = True) -> None:
+        super().__init__()
+        if timm is None:
+            raise RuntimeError("timm is required to instantiate the Swin backbone")
+
+        self.backbone = timm.create_model(
+            "swin_tiny_patch4_window7_224",
+            pretrained=pretrained,
+            num_classes=0,
+            global_pool="",
+        )
+        self.cbam = CBAM(self.backbone.num_features)
+        self.pool = nn.AdaptiveAvgPool2d(1)
+
+        self.ssi_mlp = nn.Sequential(
+            nn.Linear(ssi_input_dim, 64),
+            nn.ReLU(),
+            nn.Dropout(0.2),
+            nn.Linear(64, 32),
+            nn.ReLU(),
+        )
+
+        fusion_dim = self.backbone.num_features + 32
+        self.classifier = nn.Sequential(
+            nn.Linear(fusion_dim, 256),
+            nn.ReLU(),
+            nn.Dropout(0.3),
+            nn.Linear(256, num_classes),
+        )
+        self.num_classes = num_classes
+
+    def forward(self, img: torch.Tensor, ssi: torch.Tensor) -> torch.Tensor:
+        x = self.backbone.forward_features(img)  # [B, 768, 7, 7]
+        x = self.cbam(x)
+        x = self.pool(x)
+        x = torch.flatten(x, 1)  # [B, 768]
+
+        ssi_feat = self.ssi_mlp(ssi)  # [B, 32]
+
+        fused = torch.cat([x, ssi_feat], dim=1)  # [B, 800]
+        out = self.classifier(fused)  # [B, num_classes]
+        return out
+
+
+__all__ = ["SSI_SwinFusionNet"]

--- a/train.py
+++ b/train.py
@@ -1,0 +1,96 @@
+import argparse
+import os
+
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader
+from torchvision import transforms
+
+from src.data import FusionDataset
+from src.models import SSI_SwinFusionNet
+
+
+def train(
+    csv_path: str,
+    output_dir: str,
+    epochs: int = 5,
+    batch_size: int = 8,
+    lr: float = 1e-4,
+    device: str = "cpu",
+) -> None:
+    """Simple training loop for :class:`SSI_SwinFusionNet`."""
+
+    transform = transforms.ToTensor()
+    train_ds = FusionDataset(csv_path, split="train", transform=transform)
+    val_ds = FusionDataset(csv_path, split="val", transform=transform, label_map=train_ds.label_map)
+
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=batch_size)
+
+    model = SSI_SwinFusionNet(num_classes=len(train_ds.label_map), ssi_input_dim=train_ds[0][1].shape[0])
+    model.to(device)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.parameters(), lr=lr)
+
+    for epoch in range(epochs):
+        model.train()
+        running_loss = 0.0
+        for imgs, ssis, labels in train_loader:
+            imgs = imgs.to(device)
+            ssis = ssis.to(device)
+            labels = labels.to(device)
+            optimizer.zero_grad()
+            outputs = model(imgs, ssis)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item() * imgs.size(0)
+
+        val_loss = 0.0
+        correct = 0
+        total = 0
+        model.eval()
+        with torch.no_grad():
+            for imgs, ssis, labels in val_loader:
+                imgs = imgs.to(device)
+                ssis = ssis.to(device)
+                labels = labels.to(device)
+                outputs = model(imgs, ssis)
+                loss = criterion(outputs, labels)
+                val_loss += loss.item() * imgs.size(0)
+                preds = outputs.argmax(1)
+                correct += (preds == labels).sum().item()
+                total += labels.size(0)
+
+        print(
+            f"Epoch {epoch + 1}/{epochs} - "
+            f"train_loss: {running_loss / len(train_ds):.4f} "
+            f"val_loss: {val_loss / len(val_ds):.4f} "
+            f"val_acc: {correct / total:.4f}"
+        )
+
+    os.makedirs(output_dir, exist_ok=True)
+    torch.save(model.state_dict(), os.path.join(output_dir, "model.pth"))
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(description="Train SSI Swin fusion model")
+    parser.add_argument("--csv-path", type=str, required=True, help="Fusion CSV file")
+    parser.add_argument("--output-dir", type=str, default="checkpoints", help="Output directory")
+    parser.add_argument("--epochs", type=int, default=5, help="Number of training epochs")
+    parser.add_argument("--batch-size", type=int, default=8, help="Batch size")
+    parser.add_argument("--lr", type=float, default=1e-4, help="Learning rate")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        help="Computation device",
+    )
+    args = parser.parse_args()
+    train(args.csv_path, args.output_dir, args.epochs, args.batch_size, args.lr, args.device)
+
+
+if __name__ == "__main__":
+    cli()
+


### PR DESCRIPTION
## Summary
- implement CBAM attention blocks
- implement SSI Swin fusion network
- add training and evaluation utilities
- expose a main entrypoint
- document example usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688c2c278f48832fb32f3f6f12db665c