### PR TITLE
Add training script and preprocessing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
 # SSI_Swin_Fusion
-Projet de classification FBG avec SSI + Swin Transformer + CBAM
+
+This project performs classification of FBG measurements using a fusion of CWT images and SSI vectors with a Swin Transformer backbone.
+
+## Dataset preparation
+
+The raw `FST` dataset (not provided here) must first be segmented and split into train/val/test sets. The preprocessing utilities found in `data_preprocessing/` wrap the functions of `src.data` and expose simple CLIs.
+
+### 1. Generate segments and split
+```bash
+python data_preprocessing/segments_generation.py \
+    --data-dir /path/to/FST \
+    --output-dir /path/to/preprocessed
+```
+This creates `segments_fbg.pkl` and `split_segments.pkl` in the given output directory.
+
+### 2. Generate CWT images
+```bash
+python data_preprocessing/generate_cwt_images.py \
+    --segments-path /path/to/preprocessed/segments_fbg.pkl \
+    --split-path /path/to/preprocessed/split_segments.pkl \
+    --output-dir /path/to/CWT_images \
+    --model-path /path/to/ffdnet.pth \
+    --device cuda
+```
+`--model-path` can be omitted to use the pretrained FFDNet available in `timm`.
+
+### 3. Generate SSI vectors
+```bash
+python data_preprocessing/generate_ssi_vectors.py \
+    --segments-path /path/to/preprocessed/segments_fbg.pkl \
+    --split-path /path/to/preprocessed/split_segments.pkl \
+    --output-dir /path/to/SSI_vectors \
+    --decim 4 --lags 40 --order 20 --top-k 10
+```
+SSI frequencies are saved for every segment in `SSI_vectors/train|val|test`.
+
+### 4. Create the fusion CSV
+```bash
+python data_preprocessing/create_fusion_csv.py \
+    --cwt-dir /path/to/CWT_images \
+    --ssi-dir /path/to/SSI_vectors \
+    --weights-csv /path/to/weights.csv \
+    --output-csv /path/to/dataset_fusion_weighted.csv
+```
+If `--weights-csv` is provided, weighting coefficients are applied to all SSI vectors before creating the metadata CSV.
+
+## Training and evaluation
+
+Training is handled by `src/train.py`. It loads the fusion CSV, trains a small model combining a Swin Transformer with an SSI branch and reports validation accuracy after every epoch.
+
+Example command:
+```bash
+python -m src.train \
+    --csv-path /path/to/dataset_fusion_weighted.csv \
+    --output-dir runs \
+    --epochs 10 \
+    --batch-size 32 \
+    --lr 1e-4 \
+    --device cuda
+```
+The trained weights are saved to `runs/fusion_model.pt`. The script prints the validation loss and accuracy so it can be used for basic evaluation.

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,117 @@
+import argparse
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchvision.transforms as T
+from torch.utils.data import DataLoader
+
+import timm
+
+from src.data import FusionDataset
+
+
+class FusionModel(nn.Module):
+    """Simple fusion model using a Swin Transformer backbone and an SSI branch."""
+
+    def __init__(self, ssi_dim: int, num_classes: int) -> None:
+        super().__init__()
+        self.backbone = timm.create_model(
+            "swin_tiny_patch4_window7_224", pretrained=True, num_classes=0
+        )
+        self.fc_ssi = nn.Linear(ssi_dim, 128)
+        self.classifier = nn.Linear(self.backbone.num_features + 128, num_classes)
+
+    def forward(self, images: torch.Tensor, ssi_vecs: torch.Tensor) -> torch.Tensor:
+        img_feat = self.backbone(images)
+        ssi_feat = F.relu(self.fc_ssi(ssi_vecs))
+        feat = torch.cat((img_feat, ssi_feat), dim=1)
+        return self.classifier(feat)
+
+
+def train_epoch(model, loader, optimizer, criterion, device):
+    model.train()
+    total_loss = 0.0
+    correct = 0
+    total = 0
+    for imgs, vecs, labels in loader:
+        imgs = imgs.to(device)
+        vecs = vecs.to(device)
+        labels = labels.to(device)
+        optimizer.zero_grad()
+        outputs = model(imgs, vecs)
+        loss = criterion(outputs, labels)
+        loss.backward()
+        optimizer.step()
+        total_loss += loss.item() * imgs.size(0)
+        preds = outputs.argmax(1)
+        correct += (preds == labels).sum().item()
+        total += imgs.size(0)
+    return total_loss / total, correct / total
+
+
+def evaluate(model, loader, criterion, device):
+    model.eval()
+    total_loss = 0.0
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for imgs, vecs, labels in loader:
+            imgs = imgs.to(device)
+            vecs = vecs.to(device)
+            labels = labels.to(device)
+            outputs = model(imgs, vecs)
+            loss = criterion(outputs, labels)
+            total_loss += loss.item() * imgs.size(0)
+            preds = outputs.argmax(1)
+            correct += (preds == labels).sum().item()
+            total += imgs.size(0)
+    return total_loss / total, correct / total
+
+
+def main(args: argparse.Namespace) -> None:
+    device = torch.device(args.device)
+    transform = T.Compose([T.Resize((224, 224)), T.ToTensor()])
+
+    train_ds = FusionDataset(args.csv_path, split="train", transform=transform)
+    val_ds = FusionDataset(
+        args.csv_path, split="val", transform=transform, label_map=train_ds.label_map
+    )
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=args.batch_size)
+
+    ssi_dim = int(np.load(train_ds.data.iloc[0]["ssi_path"]).shape[0])
+    num_classes = len(train_ds.label_map)
+    model = FusionModel(ssi_dim=ssi_dim, num_classes=num_classes).to(device)
+
+    criterion = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    for epoch in range(1, args.epochs + 1):
+        train_loss, train_acc = train_epoch(model, train_loader, optimizer, criterion, device)
+        val_loss, val_acc = evaluate(model, val_loader, criterion, device)
+        print(
+            f"Epoch {epoch}/{args.epochs} "
+            f"train_loss={train_loss:.4f} train_acc={train_acc:.4f} "
+            f"val_loss={val_loss:.4f} val_acc={val_acc:.4f}"
+        )
+
+    ckpt_path = os.path.join(args.output_dir, "fusion_model.pt")
+    torch.save(model.state_dict(), ckpt_path)
+    print(f"Saved model to {ckpt_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Train fusion model")
+    parser.add_argument("--csv-path", type=str, required=True, help="Fusion CSV file")
+    parser.add_argument("--output-dir", type=str, default="runs", help="Checkpoint directory")
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
## Summary
- document full preprocessing and training workflow in README
- implement a simple training script using the fusion dataset

## Testing
- `pytest -q`
- `python -m py_compile src/train.py`

------
https://chatgpt.com/codex/tasks/task_e_688c2c2cd410832fb7657a8f903f2653