### PR TITLE
Document hawk_data usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # SSI_Swin_Fusion
 Projet de classification FBG avec SSI + Swin Transformer + CBAM
+
+## hawk_data et jeux de données
+
+Les scripts de préparation de données utilisent le paquet `hawk_data` qui fournit
+le chargeur du jeu de données FST. Ce paquet n'est pas inclus dans le
+répertoire car il est distribué séparément. Pour l'obtenir, clonez le
+répertoire correspondant et installez‑le en mode « editable » :
+
+```bash
+git clone <URL_to_hawk_data_repo>
+pip install -e hawk_data
+```
+
+Une fois installé, la classe `hawk_data.FST` sera disponible pour les scripts
+et permettra de charger les signaux bruts.
+
+## Génération des segments
+
+`data_preprocessing/segments_generation.py` génère des segments d'une seconde à
+partir des signaux FBG et crée un partage train/val/test :
+
+```bash
+python data_preprocessing/segments_generation.py \
+    --data-dir /chemin/vers/FST \
+    --output-dir /chemin/vers/sortie
+```
+
+Les fichiers `segments_fbg.pkl` et `split_segments.pkl` sont alors sauvegardés
+dans le répertoire spécifié.

--- a/data_preprocessing/segments_generation.py
+++ b/data_preprocessing/segments_generation.py
@@ -1,3 +1,8 @@
+"""Generate 1 s segments from the FST dataset.
+
+Requires the external package :mod:`hawk_data` (see README).
+"""
+
 import argparse
 import os
 import pickle
@@ -33,17 +38,21 @@ def main(data_dir: str, output_dir: str) -> None:
 
 
 def cli() -> None:
-    parser = argparse.ArgumentParser(description="Generate FBG segments and split")
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate 1 s segments from the FST dataset (requires hawk_data)"
+        )
+    )
     parser.add_argument(
         "--data-dir",
         type=str,
-        default="/content/drive/MyDrive/FST",
+        default="/path/to/FST",
         help="Directory containing the raw FBG dataset",
     )
     parser.add_argument(
         "--output-dir",
         type=str,
-        default="/content/drive/MyDrive",
+        default="./",
         help="Directory where the pickle files will be stored",
     )
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- document `hawk_data` in the README
- clarify `segments_generation.py` CLI

## Testing
- `python -m py_compile data_preprocessing/segments_generation.py`


------
https://chatgpt.com/codex/tasks/task_e_688c2c2c05dc832fa5f4a2bc43882c45