### PR TITLE
Improve install docs and dataset defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 This project performs classification of FBG measurements using a fusion of CWT images and SSI vectors with a Swin Transformer backbone.
 
+## Installation
+
+```bash
+pip install -r requirements.txt
+pip install git+https://github.com/MDCHAMP/hawk-data
+```
+
 ## Dataset preparation
 
 The raw `FST` dataset (not provided here) must first be segmented and split into train/val/test sets. The preprocessing utilities found in `data_preprocessing/` wrap the functions of `src.data` and expose simple CLIs.

--- a/eval.py
+++ b/eval.py
@@ -2,7 +2,6 @@ import argparse
 
 import torch
 from torch.utils.data import DataLoader
-from torchvision import transforms
 
 from src.data import FusionDataset
 from src.models import SSI_SwinFusionNet
@@ -16,8 +15,7 @@ def evaluate(
 ) -> float:
     """Evaluate a trained :class:`SSI_SwinFusionNet` on the test split."""
 
-    transform = transforms.ToTensor()
-    dataset = FusionDataset(csv_path, split="test", transform=transform)
+    dataset = FusionDataset(csv_path, split="test")
     loader = DataLoader(dataset, batch_size=batch_size)
 
     model = SSI_SwinFusionNet(num_classes=len(dataset.label_map), ssi_input_dim=dataset[0][1].shape[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas
 Pillow
 pywt
 scikit-image
+git+https://github.com/MDCHAMP/hawk-data

--- a/src/data/fusion_dataset.py
+++ b/src/data/fusion_dataset.py
@@ -32,6 +32,17 @@ class FusionDataset(Dataset):
         self.split = split
         self.data = pd.read_csv(csv_path)
         self.data = self.data[self.data["split"] == split].reset_index(drop=True)
+        if transform is None:
+            transform = T.Compose(
+                [
+                    T.Resize((224, 224)),
+                    T.ToTensor(),
+                    T.Normalize(
+                        mean=[0.485, 0.456, 0.406],
+                        std=[0.229, 0.224, 0.225],
+                    ),
+                ]
+            )
         self.transform = transform
 
         if label_map is None:
@@ -46,7 +57,7 @@ class FusionDataset(Dataset):
     def __getitem__(self, idx: int):  # type: ignore[override]
         row = self.data.iloc[idx]
         image = Image.open(row["image_path"]).convert("RGB")
-        image = self.transform(image) if self.transform else T.ToTensor()(image)
+        image = self.transform(image)
         ssi_vector = torch.tensor(np.load(row["ssi_path"]), dtype=torch.float32)
         label = torch.tensor(self.label_map[row["label"]], dtype=torch.long)
         return image, ssi_vector, label

--- a/src/train.py
+++ b/src/train.py
@@ -5,7 +5,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import torchvision.transforms as T
 from torch.utils.data import DataLoader
 
 import timm
@@ -73,11 +72,9 @@ def evaluate(model, loader, criterion, device):
 
 def main(args: argparse.Namespace) -> None:
     device = torch.device(args.device)
-    transform = T.Compose([T.Resize((224, 224)), T.ToTensor()])
-
-    train_ds = FusionDataset(args.csv_path, split="train", transform=transform)
+    train_ds = FusionDataset(args.csv_path, split="train")
     val_ds = FusionDataset(
-        args.csv_path, split="val", transform=transform, label_map=train_ds.label_map
+        args.csv_path, split="val", label_map=train_ds.label_map
     )
     train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True)
     val_loader = DataLoader(val_ds, batch_size=args.batch_size)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,10 @@
+import torch
+from src.models import SSI_SwinFusionNet
+
+def test_forward_shape():
+    model = SSI_SwinFusionNet(num_classes=4, ssi_input_dim=64, pretrained=False)
+    imgs = torch.rand(2, 3, 224, 224)
+    ssis = torch.rand(2, 64)
+    out = model(imgs, ssis)
+    assert out.shape == (2, 4)
+

--- a/train.py
+++ b/train.py
@@ -4,7 +4,6 @@ import os
 import torch
 from torch import nn, optim
 from torch.utils.data import DataLoader
-from torchvision import transforms
 
 from src.data import FusionDataset
 from src.models import SSI_SwinFusionNet
@@ -20,9 +19,8 @@ def train(
 ) -> None:
     """Simple training loop for :class:`SSI_SwinFusionNet`."""
 
-    transform = transforms.ToTensor()
-    train_ds = FusionDataset(csv_path, split="train", transform=transform)
-    val_ds = FusionDataset(csv_path, split="val", transform=transform, label_map=train_ds.label_map)
+    train_ds = FusionDataset(csv_path, split="train")
+    val_ds = FusionDataset(csv_path, split="val", label_map=train_ds.label_map)
 
     train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
     val_loader = DataLoader(val_ds, batch_size=batch_size)


### PR DESCRIPTION
## Summary
- add ImageNet normalization to `FusionDataset`
- use dataset defaults in train and eval scripts
- document environment installation and hawk_data
- list hawk_data in requirements
- add a basic forward-pass test for `SSI_SwinFusionNet`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688c331f6358832fa8766d14ffc0f66b