### PR TITLE
Add default transform and test script

### DIFF
--- a/src/data/fusion_dataset.py
+++ b/src/data/fusion_dataset.py
@@ -6,7 +6,21 @@ import numpy as np
 import torch
 from torch.utils.data import Dataset
 from PIL import Image
-import torchvision.transforms as T
+from torchvision import transforms
+
+# Default transform resizing the image to 224x224 and applying ImageNet
+# normalization. This matches the expectations of the Swin Transformer
+# backbone used in the model.
+default_transform = transforms.Compose(
+    [
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+        transforms.Normalize(
+            mean=[0.485, 0.456, 0.406],
+            std=[0.229, 0.224, 0.225],
+        ),
+    ]
+)
 
 
 class FusionDataset(Dataset):
@@ -33,16 +47,7 @@ class FusionDataset(Dataset):
         self.data = pd.read_csv(csv_path)
         self.data = self.data[self.data["split"] == split].reset_index(drop=True)
         if transform is None:
-            transform = T.Compose(
-                [
-                    T.Resize((224, 224)),
-                    T.ToTensor(),
-                    T.Normalize(
-                        mean=[0.485, 0.456, 0.406],
-                        std=[0.229, 0.224, 0.225],
-                    ),
-                ]
-            )
+            transform = default_transform
         self.transform = transform
 
         if label_map is None:

--- a/test_model_fusion.py
+++ b/test_model_fusion.py
@@ -1,0 +1,7 @@
+import torch
+from src.models.swin import SSI_SwinFusionNet
+
+model = SSI_SwinFusionNet(num_classes=4, ssi_input_dim=64, pretrained=False)
+img = torch.randn(2, 3, 224, 224)
+ssi = torch.randn(2, 64)
+print("Output shape:", model(img, ssi).shape)


### PR DESCRIPTION
## Summary
- define a reusable `default_transform` in `FusionDataset`
- use it when no transform is provided
- add a `test_model_fusion.py` helper script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688c34eead60832fbf8c059034b2cfe3